### PR TITLE
Connection tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Holoports-monitor
 
-Webpage for showing list of HoloPorts and their current status, based on the mongodb collection at `host_statistics.holoport_status`.
+A set of web-based tools for monitoring status of holoports on Holo Networks. Deployed to http://network-statistics.holo.host/holoports/.
 
-Site is available at network-statistics.holo.host
+#### List of Holoports
+
+Shows data reported by each Holoport via `netstatsd` service in form of a table with filters. Includes each holoport that reported it's status within last 24h and displays the most recent record. Under the hood queries collection `host_statistics.holoport_status`.
+
+#### Connectivity tester
+
+Tool for testing connection from browser to Holoport via Holo Networks: browser -> router-gateway -> zerotier-layer -> holoport.
+
+Once started in the browser, script will query `hp-stats-api` for all the holoports on-line within last 60 min. Then script will try on each holoport to establish http connection with `https://<holoport_url>/` and to open a websocket with `wss://<holoport_url>/hosting/`. Script assumes 10s timeout.
+
+Finally success rate is reported.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,3 @@ Tool for testing connection from browser to Holoport via Holo Networks: browser 
 Once started in the browser, script will query `hp-stats-api` for all the holoports on-line within last 60 min. Then script will try on each holoport to establish http connection with `https://<holoport_url>/` and to open a websocket with `wss://<holoport_url>/hosting/`. Script assumes 10s timeout.
 
 Finally success rate is reported.
-
-
-TODO:
- - currently in hp-stats-api/list-available minimum granularity of a request is a day - therefore connection tester will call all the HPs available within last 24 h, not 60 min

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ Tool for testing connection from browser to Holoport via Holo Networks: browser 
 Once started in the browser, script will query `hp-stats-api` for all the holoports on-line within last 60 min. Then script will try on each holoport to establish http connection with `https://<holoport_url>/` and to open a websocket with `wss://<holoport_url>/hosting/`. Script assumes 10s timeout.
 
 Finally success rate is reported.
+
+
+TODO:
+ - currently in hp-stats-api/list-available minimum granularity of a request is a day - therefore connection tester will call all the HPs available within last 24 h, not 60 min

--- a/connection-tester/index.html
+++ b/connection-tester/index.html
@@ -7,7 +7,8 @@
   </head>
   <body>
     <div><a href="/">< Back</a></div>
-    <span class="test-button" onclick="startTest()">Start connection test</span>
+    <span id="test-button">Start connection test</span>
+    <div id="test-results"></div>
     <script src="/js/tester.js"></script>
   </body>
 </html>

--- a/connection-tester/index.html
+++ b/connection-tester/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+      <meta charset="utf-8">
+      <title>Connection tester</title>
+      <link href="/css/main.css" rel="stylesheet">
+  </head>
+  <body>
+    <div><a href="/">< Back</a></div>
+    <span class="test-button" onclick="startTest()">Start connection test</span>
+    <script src="/js/tester.js"></script>
+  </body>
+</html>

--- a/css/main.css
+++ b/css/main.css
@@ -14,17 +14,11 @@ td.too-long {
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+  cursor: pointer;
 }
 
-td.too-long:hover {
-  overflow: initial;
-}
-
-td.too-long:hover > div {
-  background: white;
-  position: absolute;
-  margin: -0.5em 0;
-  z-index: 1;
+td.too-long > div:hover {
+  font-weight: bold;
 }
 
 .success {
@@ -36,6 +30,15 @@ td.too-long:hover > div {
   color: orangered;
   cursor: pointer;
   text-align: center;
+}
+
+.warning a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.warning a:hover {
+  font-weight: bold;
 }
 
 .helpBtn {
@@ -52,5 +55,33 @@ table.TF td {
   padding: 8px 14px;
   line-height: 4em;
   color: #352e22;
+  cursor: pointer;
+}
+
+#table-container {
+  position: relative;
+}
+
+#modal {
+  display: none;
+  position: absolute;
+  top: 0;
+  height: 13em;
+  width: 40%;
+  margin: 0 auto;
+  padding: 3em;
+  background: white;
+  left: 30%;
+  border-radius: 10px;
+  border: solid 1px grey;
+}
+
+#modal-button {
+  border-radius: 2em;
+  position: absolute;
+  bottom: 3em;
+  right: 3em;
+  background: #fc471e;
+  padding: 0.7em 1.2em;
   cursor: pointer;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -12,8 +12,19 @@ body {
 
 td.too-long {
   text-overflow: ellipsis;
-  /* overflow: hidden; */
+  overflow: hidden;
   white-space: nowrap;
+}
+
+td.too-long:hover {
+  overflow: initial;
+}
+
+td.too-long:hover > div {
+  background: white;
+  position: absolute;
+  margin: -0.5em 0;
+  z-index: 1;
 }
 
 .success {
@@ -33,4 +44,13 @@ td.too-long {
 
 table.TF td {
   text-align: center;
+}
+
+.test-button {
+  border-radius: 7px;
+  background: #00bdff73;
+  padding: 6px 11px;
+  line-height: 4em;
+  color: #352e22;
+  cursor: pointer;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -46,10 +46,10 @@ table.TF td {
   text-align: center;
 }
 
-.test-button {
+#test-button {
   border-radius: 7px;
   background: #00bdff73;
-  padding: 6px 11px;
+  padding: 8px 14px;
   line-height: 4em;
   color: #352e22;
   cursor: pointer;

--- a/index.html
+++ b/index.html
@@ -2,12 +2,26 @@
 <html lang="en">
   <head>
       <meta charset="utf-8">
-      <title>Table of HoloPorts</title>
+      <title>Holoports monitor</title>
       <link href="css/main.css" rel="stylesheet">
   </head>
   <body>
-    <table id="demo">Loading holoports...</table>
-    <script src="tablefilter/tablefilter.js"></script>
-    <script src="js/index.js"></script>
+    <a href="/list/">List of Holoports</a>
+    <p>
+      Shows data reported by each Holoport via <em>netstatsd</em> service in form of a table with filters. Includes each holoport that reported it's status within last 24h and displays the most recent record. Under the hood queries collection <em>host_statistics.holoport_status</em>.
+    </p>
+    <p>
+      &nbsp;
+    </p>
+    <a href="/connection-tester/">Connectivity tester</a>
+    <p>
+      Tool for testing connection from browser to Holoport via Holo Networks: browser -> router-gateway -> zerotier-layer -> holoport.
+    </p>
+    <p>
+      Once started in the browser, script will query `hp-stats-api` for all the holoports on-line within last 60 min. Then script will try on each holoport to establish http connection with `https://<holoport_url>/` and to open a websocket with `wss://<holoport_url>/hosting/`. Script assumes 10s timeout.
+    </p>
+    <p>
+      Finally success rate is reported.
+    </p>
   </body>
 </html>

--- a/js/list.js
+++ b/js/list.js
@@ -4,8 +4,18 @@ async function getData() {
   return availableHoloportsDetails;
 }
 
+function show_modal(arr) {
+  document.querySelector('#modal-inner').innerHTML = arr;
+  document.querySelector('#modal').style.display = 'block';
+  document.querySelector('#modal').style.top = window.scrollY + 20 + 'px';
+}
+
+function hide_modal() {
+  document.querySelector('#modal').style.display = 'none';
+}
+
 function timeSince(date) {
-  const seconds = Math.floor(new Date() / 1000) - date;
+  const seconds = Math.floor(new Date() / 1000) - date / 1000;
   let interval = seconds / 31536000;
 
   if (interval > 1) {
@@ -43,8 +53,9 @@ function getSourceChains(hostingInfo) {
   return result;
 }
 
-function printRow(hp) {
-  hp.timestamp = timeSince(hp.timestamp) + ` ago`;
+function printRow(hp, i) {
+  hp.debug = hp.lastZerotierOnline;
+  hp.lastZerotierOnline = timeSince(hp.lastZerotierOnline) + ` ago`;
   hp.totalSourceChains = getSourceChains(hp.hostingInfo);
 
   let successCheck;
@@ -58,17 +69,25 @@ function printRow(hp) {
     hp[key] = (hp[key]===null)?"-":hp[key];
   }
 
+  let errorRow
+  if (hp.errors.length === 0) {
+    errorRow = '<td class="success">no</td>'
+  } else {
+    errorRow = '<td class="warning"><span onClick="alert(data['+i+'].errors)">YES</span></td>'
+  }
+
   return `
     <tr>
-      <td class="too-long" title="${hp.holoportId}">${hp.holoportId}</td>
-      <td>${hp.ztIp}</td>
-      <td>${hp.timestamp}</td>
+      <td title="${hp.holoportId}">${hp.holoportId}</td>
+      <td>${hp.zerotierIp}</td>
+      <td>${hp.lastZerotierOnline}</td>
       <td>${hp.sshStatus}</td>
       <td>${hp.holoNetwork}</td>
       <td>${hp.channel}</td>
       <td title="${hp.holoportModel}">${hp.holoportModel}</td>
-      <td class="too-long"><div>${hp.channelVersion}</div></td>
-      <td class="too-long"><div>${hp.hposVersion}</div></td>
+      <td class="too-long"><div onClick="alert('${hp.channelVersion}')">${hp.channelVersion.substring(0,7)}</div></td>
+      <td class="too-long"><div onClick="alert('${hp.hposVersion}')">${hp.hposVersion.substring(0,7)}</div></td>
+      ${errorRow}
     </tr>
   `;
 }
@@ -79,19 +98,20 @@ function buildTable(hps) {
       <tr>
           <th>HoloPort Id</th>
           <th>Zerotier IP</th>
-          <th>Timestamp</th>
+          <th>Last seen on ZT</th>
           <th>SSH enabled</th>
           <th>Holo Network</th>
           <th>Channel</th>
           <th>Model</th>
           <th>Channel Version</th>
           <th>HPOS Version</th>
+          <th>Errors</th>
       </tr>
     </thead>
   <tbody>`;
 
-  for (const hp of hps) {
-    innerHtml += printRow(hp);
+  for (let i = 0; i < data.length; i++) {
+    innerHtml += printRow(data[i], i);
   }
 
   innerHtml += `</tbody>`;
@@ -101,16 +121,19 @@ function buildTable(hps) {
 
 getData()
   .then(data => {
+    // makes data available to js outside of this code block
+    window.data = data;
     buildTable(data);
 
     const filtersConfig = {
-        base_path: '/tablefilter/',
+        base_path: '/holoports/tablefilter/',
         col_3: 'select',
         col_4: 'select',
         col_5: 'select',
         col_6: 'select',
         col_7: 'select',
         col_8: 'select',
+        col_9: 'select',
         alternate_rows: true,
         rows_counter: true,
         mark_active_columns: true,
@@ -122,7 +145,7 @@ getData()
         col_widths: [
             '450px', '130px', '100px', '100px',
             '100px', '100px', '100px',
-            '120px', '100px', '120px'
+            '120px', '100px', '70px'
         ],
         extensions:[{ name: 'sort' }]
     };

--- a/js/list.js
+++ b/js/list.js
@@ -63,11 +63,12 @@ function printRow(hp) {
       <td class="too-long" title="${hp.holoportId}">${hp.holoportId}</td>
       <td>${hp.ztIp}</td>
       <td>${hp.timestamp}</td>
+      <td>${hp.sshStatus}</td>
       <td>${hp.holoNetwork}</td>
       <td>${hp.channel}</td>
       <td title="${hp.holoportModel}">${hp.holoportModel}</td>
-      <td class="too-long" title="${hp.channelVersion}">${hp.channelVersion}</td>
-      <td class="too-long" title="${hp.hposVersion}">${hp.hposVersion}</td>
+      <td class="too-long"><div>${hp.channelVersion}</div></td>
+      <td class="too-long"><div>${hp.hposVersion}</div></td>
     </tr>
   `;
 }
@@ -79,11 +80,12 @@ function buildTable(hps) {
           <th>HoloPort Id</th>
           <th>Zerotier IP</th>
           <th>Timestamp</th>
+          <th>SSH enabled</th>
           <th>Holo Network</th>
           <th>Channel</th>
           <th>Model</th>
           <th>Channel Version</th>
-          <th>HPOS Version</th>   
+          <th>HPOS Version</th>
       </tr>
     </thead>
   <tbody>`;
@@ -102,22 +104,23 @@ getData()
     buildTable(data);
 
     const filtersConfig = {
-        base_path: 'tablefilter/',
+        base_path: '/tablefilter/',
         col_3: 'select',
         col_4: 'select',
         col_5: 'select',
         col_6: 'select',
         col_7: 'select',
+        col_8: 'select',
         alternate_rows: true,
         rows_counter: true,
         mark_active_columns: true,
         col_types: [
-            'string', 'string', 'string',
+            'string', 'string', 'string', 'bool',
             'string', 'string', 'string',
             'string', 'string', 'string'
         ],
         col_widths: [
-            '450px', '130px', '100px',
+            '450px', '130px', '100px', '100px',
             '100px', '100px', '100px',
             '120px', '100px', '120px'
         ],
@@ -126,4 +129,5 @@ getData()
 
     const tf = new TableFilter('demo', filtersConfig);
     tf.init();
+    document.querySelector('#loading').remove();
   });

--- a/js/tester.js
+++ b/js/tester.js
@@ -1,5 +1,5 @@
 /**
- * Query hp-stats-api for holoports that are on-line within last 1 day
+ * Query hp-stats-api for holoports that are on-line within last 60 min
  *
  * @returns {Array<Holoport>} list of holoports
  */

--- a/js/tester.js
+++ b/js/tester.js
@@ -7,9 +7,9 @@ async function getData() {
   const availableHoloportsResponse = await fetch('https://network-statistics.holo.host/hosts/list-available?days=1');
   let availableHoloportsDetails = await availableHoloportsResponse.json()
 
-  // API returns entries from last 24h, while we want only last 60 min
-  const cutoffTimestamp = parseInt(Date.now()/1000) - 3600;
-  return availableHoloportsDetails.filter(el => el.timestamp >= cutoffTimestamp);
+  // const cutoffTimestamp = parseInt(Date.now()/1000) - 3600; // API returns entries from last 24h, while we want only last 60 min
+  // Return only holoports without errors
+  return availableHoloportsDetails.filter(el => el.errors.length === 0);
 }
 
 /**

--- a/js/tester.js
+++ b/js/tester.js
@@ -1,0 +1,5 @@
+
+  // document.querySelector('#loading').remove();
+  function startTest() {
+    alert("abba");
+  }

--- a/js/tester.js
+++ b/js/tester.js
@@ -1,5 +1,107 @@
+/**
+ * Query hp-stats-api for holoports that are on-line within last 1 day
+ *
+ * @returns {list} list of holoports
+ */
 
-  // document.querySelector('#loading').remove();
-  function startTest() {
-    alert("abba");
+async function getData() {
+  const availableHoloportsResponse = await fetch('https://network-statistics.holo.host/hosts/list-available?days=1');
+  let availableHoloportsDetails = await availableHoloportsResponse.json()
+  return availableHoloportsDetails;
+}
+
+/**
+ * Append DOM element of type type with text at the end of selector
+ *
+ * @param {DOM} selector
+ * @param {sting} text
+ * @param {string} type of DOM element
+ * @returns {DOM} newly inserted DOM element
+ */
+function addText(selector, text, type = "div") {
+  let span = document.createElement(type);
+  span.innerHTML = text;
+  selector.appendChild(span);
+  return span;
+}
+
+/**
+ * Based on the holo network that holoport is on format holoport's URL
+ *
+ * @param {Obj} hp
+ * @returns {string} holoport URL
+ */
+function formatUrl(hp) {
+  if (hp.holoNetwork === "devNet") {
+    return `${hp.holoportId}.holohost.dev`
+  } else {
+    return `${hp.holoportId}.holohost.net`
   }
+}
+
+// TODO: this should return a promise so that allSettled can actually can in batches
+
+/**
+ *
+ *
+ * @param {*} resultWindow DOM element fot appending results
+ * @param {Array} hps Array of holoports to query
+ * @returns null
+ */
+async function queryHoloports(hps, report) {
+  // convert array to promise
+  hps = hps.map(hp => fetch(`https://${formatUrl(hp)}`)); // TODO: adjust timeout
+  let result = await Promise.allSettled(hps);
+
+  // Analyze result
+  return {
+    httpSuccess: report.httpSuccess + result.reduce((tot, el) => {
+      if (el.status === "fulfilled" && el.value.ok) tot++;
+      return tot;
+    }, 0),
+    wssSuccess: report.wssSuccess,
+    httpError: report.httpError + result.reduce((tot, el) => {
+      if (el.status === "rejected" || (el.status === "fulfilled" && !el.value.ok)) tot++;
+      return tot;
+    }, 0),
+    wssError: report.wssError,
+    httpFailures: [],
+    wssFailures: []
+  }
+}
+
+async function startTest() {
+  let resultWindow = document.querySelector('#test-results');
+  let report = {
+    httpSuccess: 0,
+    wssSuccess: 0,
+    httpError: 0,
+    wssError: 0,
+    httpFailures: [],
+    wssFailures: []
+  };
+
+  let data = await getData();
+  let allHoloports = data.length;
+
+  addText(resultWindow, `${allHoloports} HoloPorts reported online within last 60 minutes`);
+  addText(resultWindow, "&#128640;");
+
+  let i = 1;
+  const chunk = 100; // Number of Holoports contacted async simultaneously
+
+  while (data.length > 0) {
+    addText(resultWindow, `Checking ${Math.min(i*chunk, allHoloports)} of ${allHoloports}`);
+    report = await queryHoloports(data.splice(-chunk, chunk), report);
+    i++;
+  }
+
+  // Print final report
+  addText(resultWindow, `Successfully connected to ${report.httpSuccess} holoports`);
+  addText(resultWindow, `Failed to connect to ${report.httpError} holoports`);
+  console.log(report)
+}
+
+document.querySelector("#test-button").onclick=async () => {
+  await startTest();
+}

--- a/list/index.html
+++ b/list/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+      <meta charset="utf-8">
+      <title>Table of HoloPorts</title>
+      <link href="/css/main.css" rel="stylesheet">
+  </head>
+  <body>
+    <div><a href="/">< Back</a></div>
+    <div id="loading">Loading holoports...</div>
+    <table id="demo"></table>
+    <script src="/tablefilter/tablefilter.js"></script>
+    <script src="/js/list.js"></script>
+  </body>
+</html>

--- a/list/index.html
+++ b/list/index.html
@@ -8,7 +8,13 @@
   <body>
     <div><a href="/">< Back</a></div>
     <div id="loading">Loading holoports...</div>
-    <table id="demo"></table>
+    <div id="table-container">
+      <div id="modal">
+        <div id="modal-inner"></div>
+        <div id="modal-button" onClick="hide_modal()">Close</div>
+      </div>
+      <table id="demo"></table>
+    </div>
     <script src="/tablefilter/tablefilter.js"></script>
     <script src="/js/list.js"></script>
   </body>


### PR DESCRIPTION
This PR adds a page "Connectivity tester" to network-statistics tool.

An intent behind this service is to asses how reliable is a connection with Holoport ovar HoloNetwork (`browser -> router-gateway -> zt-netowrk -> holoport`).

Script (triggered manually) will load a list of HoloPorts reported as ONLINE within last 60 minutes and try to establish both `http://` and `wss://` connection to them.

> ONLINE - means that there's an entry in `host_statistics.holoport_status` (as reported by Holoport's `netstatsd`) with timestamp within last 60 min.

#### From user perspective:
- user visits https://network-statistics.holo.host/holoports/connection-test/
- user presses button "Test connections"
- User sees:
    - XXX HPs reported online
    - querying 10 of XXX
    - querying 20 of XXX
    - etc
    - Test result:
        - YYY of XXX OK (97%)
        - Failed to HTTP: [IPs]
        - Failed to wss: [IPs]

#### Under the hood:
- render a page
- onclick of button run execute_zt_test()
    - gets all online HPs from `[host_statistics](https://network-statistics.holo.host/hosts/list-available?seconds=3600)`
    - in batches of 10 for each
        - https://<holoport_url> -> expect 200
        - open wss://<holoport_url>/hosting/ -> expect to open
        - 10s timeout
        - collect errors
    - display stats

TODO:
- [x] move index.html of holoports-monitor-ui to /list/
- [x] create new index.html at /
- [x] create new index.html at /connection-test/